### PR TITLE
Added option to set a custom double successes number

### DIFF
--- a/src/lib/d10.js
+++ b/src/lib/d10.js
@@ -1,3 +1,3 @@
 module.exports = function d10() {
-  return Math.floor(Math.random() * 11);
+  return 1 + Math.floor(Math.random() * 10);
 };

--- a/src/lib/roller.js
+++ b/src/lib/roller.js
@@ -1,21 +1,23 @@
 const d10 = require('./d10');
 
+const ascendingNumericalSort = (l, r) =>  l - r;
+
 function roll(
   dice,
-  { automaticSuccesses = 0, no10 = false, targetNum = 7 } = {},
+  { automaticSuccesses = 0, noDoubleSuccesses = false, targetNumber = 7, doubleSuccessNumber = 10 } = {},
 ) {
   if (dice < 1 || dice === undefined || typeof dice !== 'number') {
     throw new Error('Can only roll a positive number of dice.');
   }
 
-  const rolls = [...Array(dice)].map(d10).sort();
+  const rolls = [...Array(dice)].map(d10).sort(ascendingNumericalSort);
 
   const rolledSuccesses = rolls.reduce((result, next) => {
-    if (next < targetNum) {
+    if (next < targetNumber) {
       return result;
     }
 
-    return result + (next === 10 && !no10 ? 2 : 1);
+    return result + (next >= doubleSuccessNumber && !noDoubleSuccesses ? 2 : 1);  
   }, 0);
 
   return {

--- a/src/lib/roller.spec.js
+++ b/src/lib/roller.spec.js
@@ -25,12 +25,31 @@ describe('roller', () => {
   });
 
   it('should return a success when rolling a custom target number.', async () => {
-    const targetNum = 5;
+    const targetNumber = 5;
     d10.mockReturnValue(5);
 
-    const result = roll(1, { targetNum });
+    const result = roll(1, { targetNumber });
 
     expect(result.successes).toBe(1);
+  });
+
+  it('should make 10s count as 1 success not 2.', async () => {
+    const noDoubleSuccesses = true;
+    d10.mockReturnValue(10);
+
+    const result = roll(1, { noDoubleSuccesses });
+
+    expect(result.successes).toBe(1);
+  });
+
+
+  it('should double dice successes when rolling a custom double dice number from that number forwards.', async () => {
+    const doubleSuccessNumber = 9;
+    d10.mockReturnValue(9, 10);
+
+    const result = roll(2, { doubleSuccessNumber });
+
+    expect(result.successes).toBe(4);
   });
 
   it('should not return a success when rolling under a custom target number.', async () => {


### PR DESCRIPTION
Added the doubleSuccessNumber object value to the roller. Changed the name of targetNum to targetNumber and no10 to noDoubleSuccesses. Also added tests to test that doubleSuccessNumber works and that noDoubleSuccesses works as well.

This is so cool.