### PR TITLE
Added a min-height to fix the chat not collapsing

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -15,6 +15,7 @@ const LayoutGrid = styled.div`
   display: grid;
 
   min-width: ${breakpoint(BREAKPOINT_SM)};
+  min-height: 660px;
 
   grid:
     4rem auto /


### PR DESCRIPTION
Added a `min-height` to the `<LayoutGrid>` component in Layout.js to fix the problem of the chat not collapsing when you made the height of the window small. 